### PR TITLE
Backend dependency bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     //Spring doesn't manage SQLite driver versions
     implementation 'org.xerial:sqlite-jdbc:3.41.2.1'
     //Non-official dialects including SQLite
-    implementation 'org.hibernate.orm:hibernate-community-dialects:6.2.0.Final'
+    implementation 'org.hibernate.orm:hibernate-community-dialects:6.1.7.Final'
     //Commons
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     //HTTP

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.4'
+    id 'org.springframework.boot' version '3.0.5'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
@@ -23,8 +23,8 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     //Springdoc
-    implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     //JWT
     implementation 'com.auth0:java-jwt:4.3.0'
     //Database clients
@@ -32,9 +32,9 @@ dependencies {
     implementation 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.postgresql:postgresql'
     //Spring doesn't manage SQLite driver versions
-    implementation 'org.xerial:sqlite-jdbc:3.41.0.0'
+    implementation 'org.xerial:sqlite-jdbc:3.41.2.1'
     //Non-official dialects including SQLite
-    implementation 'org.hibernate.orm:hibernate-community-dialects:6.1.7.Final'
+    implementation 'org.hibernate.orm:hibernate-community-dialects:6.2.0.Final'
     //Commons
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     //HTTP

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 #Dependent on DB: testing-postgresql, testing-mariadb, testing-sqlite
 #spring:
 #  profiles:
-#    active: testing-shared,testing-mariadb
+#    active: testing-shared,testing-sqlite
 
 #PostgreSQL specific settings
 ---


### PR DESCRIPTION
Spring 3.0.4 -> 3.0.5
SQLite driver 3.41.0.0 -> 3.41.2.1
Springdoc 2.0.2 -> 2.1.0