### PR TITLE
Dependency bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.1'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot' version '3.1.2'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group 'me.bartosz1'
@@ -24,15 +24,15 @@ dependencies {
     //required for MariaDB
     implementation 'org.flywaydb:flyway-mysql'
     //Springdoc
-    implementation 'org.springdoc:springdoc-openapi-starter-common:2.1.0'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     //JWT
     implementation 'com.auth0:java-jwt:4.4.0'
     //Database clients
     implementation 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.postgresql:postgresql'
     //Commons
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
     //Tests
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,19 +10,19 @@
       "dependencies": {
         "axios": "^1.4.0",
         "chart.js": "^4.3.0",
-        "dompurify": "^3.0.2",
+        "dompurify": "^3.0.5",
         "marked": "^4.3.0",
         "phosphor-svelte": "^1.3.0",
         "svelte-chartjs": "^3.1.2",
         "svelte-cookie": "^1.0.1",
-        "svelte-french-toast": "^1.0.3",
-        "svelte-modals": "^1.2.1",
+        "svelte-french-toast": "^1.2.0",
+        "svelte-modals": "^1.3.0",
         "svelte-spa-router": "^3.3.0",
         "svelte-table": "^0.6.1"
       },
       "devDependencies": {
         "@svelte-plugins/tooltips": "^0.1.6",
-        "@sveltejs/vite-plugin-svelte": "^2.1.0",
+        "@sveltejs/vite-plugin-svelte": "^2.4.5",
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.24",
         "postcss-load-config": "^4.0.1",
@@ -30,7 +30,7 @@
         "svelte-preprocess": "^5.0.4",
         "svelte-use-form": "^2.6.2",
         "tailwindcss": "^3.3.2",
-        "typescript": "^5.0.4",
+        "typescript": "^5.1.6",
         "vite": "^4.3.9"
       }
     },
@@ -493,33 +493,57 @@
       "dev": true
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.1.0.tgz",
-      "integrity": "sha512-Bc9A8mtTGlhTICdLL/aZ+jyHI3kwtkcXremOH5xwjbNNKOTOtY8nMyG8/oZ5KK8IuUfAn1WL58Bp2tofDJBW0w==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.5.tgz",
+      "integrity": "sha512-UJKsFNwhzCVuiZd06jM/psscyNJNDwjQC+qIeb7GBJK9iWeQCcIyfcPWDvbCudfcJggY9jtxJeeaZH7uny93FQ==",
       "dev": true,
       "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.3",
         "debug": "^4.3.4",
         "deepmerge": "^4.3.1",
         "kleur": "^4.1.5",
-        "magic-string": "^0.30.0",
-        "svelte-hmr": "^0.15.1",
+        "magic-string": "^0.30.2",
+        "svelte-hmr": "^0.15.3",
         "vitefu": "^0.2.4"
       },
       "engines": {
         "node": "^14.18.0 || >= 16"
       },
       "peerDependencies": {
-        "svelte": "^3.54.0",
+        "svelte": "^3.54.0 || ^4.0.0",
         "vite": "^4.0.0"
       }
     },
-    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.3.tgz",
+      "integrity": "sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >= 16"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.2.0",
+        "svelte": "^3.54.0 || ^4.0.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
+      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -855,9 +879,9 @@
       "dev": true
     },
     "node_modules/dompurify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.2.tgz",
-      "integrity": "sha512-B8c6JdiEpxAKnd8Dm++QQxJL4lfuc757scZtcapj6qjTjrQzyq5iAyznLKVvK+77eYNiFblHBlt7MM0fOeqoKw=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.328",
@@ -1829,31 +1853,34 @@
       "integrity": "sha512-c4cXLMeG7vlAk3Q5axjxlppMJgeLLWd/6cCvo1wEL6ZwEueVHAP71SBRi9r5XmLYnCYr7eAqlK6NrYT/29KuKQ=="
     },
     "node_modules/svelte-french-toast": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-1.0.3.tgz",
-      "integrity": "sha512-HBdutlqUx5FroucvcmMJstmTJDedXayiOSXubBYW6iL5x1PdHp+bOflGx5NxsOa6+EQckJnnVv1vJYgGsg7ngQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-1.2.0.tgz",
+      "integrity": "sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==",
       "dependencies": {
-        "svelte-writable-derived": "^2.1.3"
+        "svelte-writable-derived": "^3.1.0"
+      },
+      "peerDependencies": {
+        "svelte": "^3.57.0 || ^4.0.0"
       }
     },
     "node_modules/svelte-hmr": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
-      "integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
+      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
       "dev": true,
       "engines": {
         "node": "^12.20 || ^14.13.1 || >= 16"
       },
       "peerDependencies": {
-        "svelte": ">=3.19.0"
+        "svelte": "^3.19.0 || ^4.0.0"
       }
     },
     "node_modules/svelte-modals": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/svelte-modals/-/svelte-modals-1.2.1.tgz",
-      "integrity": "sha512-7MEKUx5wb5YppkXWFGeRlYM5FMGEnpix39u9Y6GtCNTMXRDZ7DB2Z50IYLMRTMW5lOsCdtJgFbB0E3iZMKmsAA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-modals/-/svelte-modals-1.3.0.tgz",
+      "integrity": "sha512-b1Ylnyv9O6b7VYeWGJVToaVU2lw7GtErVwiEdojyfnOuZcrhNlQ5eDqbTrL3xyKz8j2VTy/QiGUl1lm/6SnQ2A==",
       "peerDependencies": {
-        "svelte": "^3.0.0"
+        "svelte": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/svelte-preprocess": {
@@ -1944,14 +1971,14 @@
       }
     },
     "node_modules/svelte-writable-derived": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-2.1.6.tgz",
-      "integrity": "sha512-vqOXuiESMZyP/kt/RD+nOk2RVHNakDm1K1hmfeGAKc4jzcSp5hEkUi43MDbkVlMurkSBlcMVTQwRQy4LcBT2lw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-3.1.0.tgz",
+      "integrity": "sha512-cTvaVFNIJ036vSDIyPxJYivKC7ZLtcFOPm1Iq6qWBDo1fOHzfk6ZSbwaKrxhjgy52Rbl5IHzRcWgos6Zqn9/rg==",
       "funding": {
         "url": "https://ko-fi.com/pixievoltno1"
       },
       "peerDependencies": {
-        "svelte": "^3.2.1"
+        "svelte": "^3.2.1 || ^4.0.0-next.1"
       }
     },
     "node_modules/tailwindcss": {
@@ -2032,16 +2059,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2392,28 +2419,44 @@
       "dev": true
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.1.0.tgz",
-      "integrity": "sha512-Bc9A8mtTGlhTICdLL/aZ+jyHI3kwtkcXremOH5xwjbNNKOTOtY8nMyG8/oZ5KK8IuUfAn1WL58Bp2tofDJBW0w==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.5.tgz",
+      "integrity": "sha512-UJKsFNwhzCVuiZd06jM/psscyNJNDwjQC+qIeb7GBJK9iWeQCcIyfcPWDvbCudfcJggY9jtxJeeaZH7uny93FQ==",
       "dev": true,
       "requires": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.3",
         "debug": "^4.3.4",
         "deepmerge": "^4.3.1",
         "kleur": "^4.1.5",
-        "magic-string": "^0.30.0",
-        "svelte-hmr": "^0.15.1",
+        "magic-string": "^0.30.2",
+        "svelte-hmr": "^0.15.3",
         "vitefu": "^0.2.4"
       },
       "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.15",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+          "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+          "dev": true
+        },
         "magic-string": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "version": "0.30.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
+          "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
           "dev": true,
           "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.13"
+            "@jridgewell/sourcemap-codec": "^1.4.15"
           }
         }
+      }
+    },
+    "@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.3.tgz",
+      "integrity": "sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
       }
     },
     "@types/node": {
@@ -2642,9 +2685,9 @@
       "dev": true
     },
     "dompurify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.2.tgz",
-      "integrity": "sha512-B8c6JdiEpxAKnd8Dm++QQxJL4lfuc757scZtcapj6qjTjrQzyq5iAyznLKVvK+77eYNiFblHBlt7MM0fOeqoKw=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A=="
     },
     "electron-to-chromium": {
       "version": "1.4.328",
@@ -3307,24 +3350,24 @@
       "integrity": "sha512-c4cXLMeG7vlAk3Q5axjxlppMJgeLLWd/6cCvo1wEL6ZwEueVHAP71SBRi9r5XmLYnCYr7eAqlK6NrYT/29KuKQ=="
     },
     "svelte-french-toast": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-1.0.3.tgz",
-      "integrity": "sha512-HBdutlqUx5FroucvcmMJstmTJDedXayiOSXubBYW6iL5x1PdHp+bOflGx5NxsOa6+EQckJnnVv1vJYgGsg7ngQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-1.2.0.tgz",
+      "integrity": "sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==",
       "requires": {
-        "svelte-writable-derived": "^2.1.3"
+        "svelte-writable-derived": "^3.1.0"
       }
     },
     "svelte-hmr": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
-      "integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
+      "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
       "dev": true,
       "requires": {}
     },
     "svelte-modals": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/svelte-modals/-/svelte-modals-1.2.1.tgz",
-      "integrity": "sha512-7MEKUx5wb5YppkXWFGeRlYM5FMGEnpix39u9Y6GtCNTMXRDZ7DB2Z50IYLMRTMW5lOsCdtJgFbB0E3iZMKmsAA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-modals/-/svelte-modals-1.3.0.tgz",
+      "integrity": "sha512-b1Ylnyv9O6b7VYeWGJVToaVU2lw7GtErVwiEdojyfnOuZcrhNlQ5eDqbTrL3xyKz8j2VTy/QiGUl1lm/6SnQ2A==",
       "requires": {}
     },
     "svelte-preprocess": {
@@ -3363,9 +3406,9 @@
       }
     },
     "svelte-writable-derived": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-2.1.6.tgz",
-      "integrity": "sha512-vqOXuiESMZyP/kt/RD+nOk2RVHNakDm1K1hmfeGAKc4jzcSp5hEkUi43MDbkVlMurkSBlcMVTQwRQy4LcBT2lw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-3.1.0.tgz",
+      "integrity": "sha512-cTvaVFNIJ036vSDIyPxJYivKC7ZLtcFOPm1Iq6qWBDo1fOHzfk6ZSbwaKrxhjgy52Rbl5IHzRcWgos6Zqn9/rg==",
       "requires": {}
     },
     "tailwindcss": {
@@ -3433,9 +3476,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@svelte-plugins/tooltips": "^0.1.6",
-    "@sveltejs/vite-plugin-svelte": "^2.1.0",
+    "@sveltejs/vite-plugin-svelte": "^2.4.5",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",
     "postcss-load-config": "^4.0.1",
@@ -18,19 +18,19 @@
     "svelte-preprocess": "^5.0.4",
     "svelte-use-form": "^2.6.2",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.6",
     "vite": "^4.3.9"
   },
   "dependencies": {
     "axios": "^1.4.0",
     "chart.js": "^4.3.0",
-    "dompurify": "^3.0.2",
+    "dompurify": "^3.0.5",
     "marked": "^4.3.0",
     "phosphor-svelte": "^1.3.0",
     "svelte-chartjs": "^3.1.2",
     "svelte-cookie": "^1.0.1",
-    "svelte-french-toast": "^1.0.3",
-    "svelte-modals": "^1.2.1",
+    "svelte-french-toast": "^1.2.0",
+    "svelte-modals": "^1.3.0",
     "svelte-spa-router": "^3.3.0",
     "svelte-table": "^0.6.1"
   }


### PR DESCRIPTION
Spring Boot dependency mgmt - 1.1.0 -> 1.1.3
Spring Boot - 3.1.1 -> 3.1.2
Apache commons - 3.12.0 -> 3.13.0
Springdoc - 2.1.0 -> 2.2.0

sveltejs/vite-plugin-svelte  - 2.1.0 -> 2.4.5
svelte-french-toast - 1.0.3 -> 1.2.0
dompurify - 3.0.2 -> 3.0.5
typescript - 5.0.4 -> 5.1.6
svelte-modals - 1.2.1 -> 1.3.0